### PR TITLE
fixed import statements and passing of foyer specific arguments after…

### DIFF
--- a/Foyer_01_SMARTS_and_Overrides.ipynb
+++ b/Foyer_01_SMARTS_and_Overrides.ipynb
@@ -109,7 +109,7 @@
    "source": [
     "import mbuild as mb\n",
     "\n",
-    "from mbuild.examples import Alkane\n",
+    "from mbuild.lib.recipes.alkane import Alkane\n",
     "\n",
     "hexane = Alkane(6)\n",
     "\n",
@@ -157,7 +157,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hexane.save('hexane.top', forcefield_files='utils/OPLSaa_alkanes.xml', references_file='hexane.bib', overwrite=True)"
+    "hexane.save('hexane.top', forcefield_files='utils/OPLSaa_alkanes.xml', \n",
+    "            overwrite=True, foyer_kwargs={'references_file':\"./hexane.bib\"})"
    ]
   },
   {
@@ -168,13 +169,6 @@
    "source": [
     "cat hexane.bib"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -193,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/Foyer_02_SMARTS_for_Non-Atomistic_Systems.ipynb
+++ b/Foyer_02_SMARTS_for_Non-Atomistic_Systems.ipynb
@@ -129,12 +129,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then simply call the save routine to apply the forcefield and output the topology file.  \n",
+    "\n",
+    "Important note, since this CG polymer does not contain dihedrals, we need to set `assert_dihedral_params` to `False`.  `assert_dihedral_params` checks to see if all quartets of sites identified by the code have associated proper dihedrals in the force field file. If a value of `assert_dihedral_params` is set to `True` (this is the default case), it will throw and exception if dihedrals are missing.  If it is set to `False`, the validation is still performed, but instead of an exception, a warning will be raised.  \n",
+    "\n",
+    "Additional automatic checks similar to `assert_dihedral_params` include:\n",
+    "* `assert_bond_params` : default `True`\n",
+    "* `assert_angle_params`: default `True`\n",
+    "* `assert_improper_params` : default `False`\n",
+    "\n",
+    " The purpose of these checks is to ensure forcefield files include definitions of all the necessary bonded parameters. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cg_polymer.save('CGpolymer.top', forcefield_files='utils/CG_polymer.xml', overwrite=True)"
+    "cg_polymer.save('CGpolymer.top', forcefield_files='utils/CG_polymer.xml', overwrite=True, \n",
+    "                foyer_kwargs={'assert_dihedral_params':False})"
    ]
   },
   {
@@ -218,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The last bit of code refactoring change the location of some of the examples and the way foyer specific arguments are passed to the mbuild save function.  This PR fixes those issues. 