### PR TITLE
Add automated testing for foyer tutorial notebooks

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests for foyer notebooks
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test notebooks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+  # daily at 06:15
+    - cron: 15 06 * * *
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: test
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install mamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment-test.yml
+          environment-name: foyer-tutorials
+
+      # linux and osx
+      - name: run nbval
+        shell: bash -l {0}
+        run: |
+          python -m pytest --nbval-lax --sanitize-with nbval_sanitize.cfg --verbose

--- a/Foyer_00_Getting_Started.ipynb
+++ b/Foyer_00_Getting_Started.ipynb
@@ -43,23 +43,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " <AtomTypes>\r\n",
-      "     <Type name=\"opls_961\" class=\"CT\" element=\"C\" mass=\"12.01100\"  def=\"[C;X4](F)(F)(F)(C)\" desc=\"perfluoroalkane CF3\" doi=\"10.1021/jp004071w\"/>\r\n",
-      "     <Type name=\"opls_962\" class=\"CT\" element=\"C\" mass=\"12.01100\"  def=\"[C;X4](F)(F)(C)(C)\" desc=\"perfluoroalkane CF2\" doi=\"10.1021/jp004071w\"/>\r\n",
-      "     <Type name=\"opls_963\" class=\"CT\" element=\"C\" mass=\"12.011\"    def=\"[C;X4](F)(C)(C)(C)\" desc=\"perfluoroalkane CF\"  doi=\"10.1021/jp004071w\"/>\r\n",
-      "     <Type name=\"opls_964\" class=\"CT\" element=\"C\" mass=\"12.011\"    def=\"[C;X4](F)(F)(F)(F)\" desc=\"perfluoroalkane CF4\" doi=\"10.1021/jp004071w\"/>\r\n",
-      "     <Type name=\"opls_965\" class=\"F\"  element=\"F\" mass=\"18.9984\"   def=\"FC\"                 desc=\"perfluoroalkane F\"   doi=\"10.1021/jp004071w\"/>\r\n",
-      " </AtomTypes>\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! sed -n 34,40p utils/OPLSaa_perfluoroalkanes.xml"
    ]
@@ -91,38 +77,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " <HarmonicBondForce>\r\n",
-      "     <Bond class1=\"CT\" class2=\"CT\" length=\"0.1529\" k=\"224262.4\"/> <!--doi=\"10.1021/ja9621760\"-->\r\n",
-      "     <Bond class1=\"CT\" class2=\"F\" length=\"0.1332\" k=\"307105.6\"/> <!--doi=\"10.1002/jcc.540130806-->\r\n",
-      " </HarmonicBondForce>\r\n",
-      " <HarmonicAngleForce>\r\n",
-      "     <Angle class1=\"CT\" class2=\"CT\" class3=\"CT\" angle=\"1.966986067\"   k=\"488.273\"/> <!--doi=\"10.1021/ja9621760\"-->\r\n",
-      "     <Angle class1=\"CT\" class2=\"CT\" class3=\"F\"  angle=\"1.91113553093\" k=\"418.4\"/>   <!--doi=\"10.1021/ja00124a002\"-->\r\n",
-      "     <Angle class1=\"F\"  class2=\"CT\" class3=\"F\"  angle=\"1.904154214\"   k=\"644.336\"/> <!--doi=\"10.1021/ja00124a002\"-->\r\n",
-      " </HarmonicAngleForce>\r\n",
-      " <RBTorsionForce>\r\n",
-      "     <Proper class1=\"CT\" type2=\"opls_962\" type3=\"opls_962\" class4=\"CT\" c0=\"14.91596\" c1=\"-22.564312\" c2=\"-39.41328\" c3=\"11.614784\" c4=\"35.446848\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
-      "     <Proper type1=\"opls_961\" type2=\"opls_963\" type3=\"opls_962\" type4=\"opls_961\" c0=\"15.85736\" c1=\"-19.940944\" c2=\"-27.606032\" c3=\"3.64008\" c4=\"28.049536\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
-      "     <Proper class1=\"F\" class2=\"CT\" class3=\"CT\" class4=\"F\" c0=\"-4.707\" c1=\"6.799\" c2=\"0.0\" c3=\"-2.092\" c4=\"0.0\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
-      "     <Proper class1=\"CT\" class2=\"CT\" class3=\"CT\" class4=\"F\" c0=\"1.4644\" c1=\"1.8828\" c2=\"0.0\" c3=\"-3.3472\" c4=\"0.0\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
-      " </RBTorsionForce>\r\n",
-      " <NonbondedForce coulomb14scale=\"0.5\" lj14scale=\"0.5\">\r\n",
-      "     <Atom type=\"opls_961\" charge=\"0.36\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
-      "     <Atom type=\"opls_962\" charge=\"0.24\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
-      "     <Atom type=\"opls_963\" charge=\"0.12\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
-      "     <Atom type=\"opls_964\" charge=\"0.48\"  sigma=\"0.35\"  epsilon=\"0.405848\"/>\r\n",
-      "     <Atom type=\"opls_965\" charge=\"-0.12\" sigma=\"0.295\" epsilon=\"0.221752\"/>\r\n",
-      " </NonbondedForce>\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! sed -n 41,62p utils/OPLSaa_perfluoroalkanes.xml"
    ]

--- a/Foyer_00_Getting_Started.ipynb
+++ b/Foyer_00_Getting_Started.ipynb
@@ -43,9 +43,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " <AtomTypes>\r\n",
+      "     <Type name=\"opls_961\" class=\"CT\" element=\"C\" mass=\"12.01100\"  def=\"[C;X4](F)(F)(F)(C)\" desc=\"perfluoroalkane CF3\" doi=\"10.1021/jp004071w\"/>\r\n",
+      "     <Type name=\"opls_962\" class=\"CT\" element=\"C\" mass=\"12.01100\"  def=\"[C;X4](F)(F)(C)(C)\" desc=\"perfluoroalkane CF2\" doi=\"10.1021/jp004071w\"/>\r\n",
+      "     <Type name=\"opls_963\" class=\"CT\" element=\"C\" mass=\"12.011\"    def=\"[C;X4](F)(C)(C)(C)\" desc=\"perfluoroalkane CF\"  doi=\"10.1021/jp004071w\"/>\r\n",
+      "     <Type name=\"opls_964\" class=\"CT\" element=\"C\" mass=\"12.011\"    def=\"[C;X4](F)(F)(F)(F)\" desc=\"perfluoroalkane CF4\" doi=\"10.1021/jp004071w\"/>\r\n",
+      "     <Type name=\"opls_965\" class=\"F\"  element=\"F\" mass=\"18.9984\"   def=\"FC\"                 desc=\"perfluoroalkane F\"   doi=\"10.1021/jp004071w\"/>\r\n",
+      " </AtomTypes>\r\n"
+     ]
+    }
+   ],
    "source": [
     "! sed -n 34,40p utils/OPLSaa_perfluoroalkanes.xml"
    ]
@@ -77,9 +91,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " <HarmonicBondForce>\r\n",
+      "     <Bond class1=\"CT\" class2=\"CT\" length=\"0.1529\" k=\"224262.4\"/> <!--doi=\"10.1021/ja9621760\"-->\r\n",
+      "     <Bond class1=\"CT\" class2=\"F\" length=\"0.1332\" k=\"307105.6\"/> <!--doi=\"10.1002/jcc.540130806-->\r\n",
+      " </HarmonicBondForce>\r\n",
+      " <HarmonicAngleForce>\r\n",
+      "     <Angle class1=\"CT\" class2=\"CT\" class3=\"CT\" angle=\"1.966986067\"   k=\"488.273\"/> <!--doi=\"10.1021/ja9621760\"-->\r\n",
+      "     <Angle class1=\"CT\" class2=\"CT\" class3=\"F\"  angle=\"1.91113553093\" k=\"418.4\"/>   <!--doi=\"10.1021/ja00124a002\"-->\r\n",
+      "     <Angle class1=\"F\"  class2=\"CT\" class3=\"F\"  angle=\"1.904154214\"   k=\"644.336\"/> <!--doi=\"10.1021/ja00124a002\"-->\r\n",
+      " </HarmonicAngleForce>\r\n",
+      " <RBTorsionForce>\r\n",
+      "     <Proper class1=\"CT\" type2=\"opls_962\" type3=\"opls_962\" class4=\"CT\" c0=\"14.91596\" c1=\"-22.564312\" c2=\"-39.41328\" c3=\"11.614784\" c4=\"35.446848\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
+      "     <Proper type1=\"opls_961\" type2=\"opls_963\" type3=\"opls_962\" type4=\"opls_961\" c0=\"15.85736\" c1=\"-19.940944\" c2=\"-27.606032\" c3=\"3.64008\" c4=\"28.049536\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
+      "     <Proper class1=\"F\" class2=\"CT\" class3=\"CT\" class4=\"F\" c0=\"-4.707\" c1=\"6.799\" c2=\"0.0\" c3=\"-2.092\" c4=\"0.0\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
+      "     <Proper class1=\"CT\" class2=\"CT\" class3=\"CT\" class4=\"F\" c0=\"1.4644\" c1=\"1.8828\" c2=\"0.0\" c3=\"-3.3472\" c4=\"0.0\" c5=\"0.0\"/> <!--doi=\"10.1021/jp004071w\"-->\r\n",
+      " </RBTorsionForce>\r\n",
+      " <NonbondedForce coulomb14scale=\"0.5\" lj14scale=\"0.5\">\r\n",
+      "     <Atom type=\"opls_961\" charge=\"0.36\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
+      "     <Atom type=\"opls_962\" charge=\"0.24\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
+      "     <Atom type=\"opls_963\" charge=\"0.12\"  sigma=\"0.35\"  epsilon=\"0.276144\"/>\r\n",
+      "     <Atom type=\"opls_964\" charge=\"0.48\"  sigma=\"0.35\"  epsilon=\"0.405848\"/>\r\n",
+      "     <Atom type=\"opls_965\" charge=\"-0.12\" sigma=\"0.295\" epsilon=\"0.221752\"/>\r\n",
+      " </NonbondedForce>\r\n"
+     ]
+    }
+   ],
    "source": [
     "! sed -n 41,62p utils/OPLSaa_perfluoroalkanes.xml"
    ]
@@ -108,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/Foyer_01_SMARTS_and_Overrides.ipynb
+++ b/Foyer_01_SMARTS_and_Overrides.ipynb
@@ -109,7 +109,6 @@
    "source": [
     "import mbuild as mb\n",
     "\n",
-
     "hexane = mb.recipes.Alkane(6)\n",
     "\n",
     "hexane.save('hexane.top', forcefield_files='utils/OPLSaa_alkanes.xml', overwrite=True)\n",
@@ -185,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/Foyer_02_SMARTS_for_Non-Atomistic_Systems.ipynb
+++ b/Foyer_02_SMARTS_for_Non-Atomistic_Systems.ipynb
@@ -234,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/Foyer_03_Creating_Force_field_Files.ipynb
+++ b/Foyer_03_Creating_Force_field_Files.ipynb
@@ -86,7 +86,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,4 +1,4 @@
-name: foyer-binder
+name: foyer-tutorials
 
 channels:
   - conda-forge
@@ -21,3 +21,5 @@ dependencies:
   - lxml
   - foyer
   - mbuild
+  - pytest
+  - nbval

--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -1,0 +1,7 @@
+[regex1]
+regex: \d{1,2}/\d{1,2}/\d{2,4}
+replace: DATE-STAMP
+
+[regex2]
+regex: \d{2}:\d{2}:\d{2}
+replace: TIME-STAMP


### PR DESCRIPTION
Previously, when breaking API changes occurred to the MoSDeF tools, a lot
of our notebooks would break silently.

Without automated testing, this can be quite difficult to keep track of,
and it is not uncommon for these notebooks to quickly fall out of sync
with the current updates.
This PR introduces a GitHub Action to create a conda environment, and
use the pytest plugin `nbval` to run tests on each notebook. This will
occur daily, for pushes and pull requests.